### PR TITLE
Added analyzer that verify if method provider for Setup() is overridable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Note: If you are using Visual Studio 2017 then you can additionally install [Moq
 * Moq1002 = Parameters provided into mock do not match any existing constructors
 * Moq1100 = Callback signature must match the signature of the mocked method
 * Moq1101 = SetupGet/SetupSet should be used for properties, not for methods
+* Moq1200 = Setup should be used only for overridable members.
 
 ## TODO
 

--- a/Source/Moq.Analyzers.Test/Data/SetupOnlyForOverridableMembers.cs
+++ b/Source/Moq.Analyzers.Test/Data/SetupOnlyForOverridableMembers.cs
@@ -1,0 +1,90 @@
+﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+#pragma warning disable SA1402 // File may only contain a single class
+#pragma warning disable SA1649 // File name must match first type name
+#pragma warning disable SA1502 // Element must not be on a single line
+namespace SetupOnlyForOverridableMembers
+{
+    using Moq;
+    public interface ISampleInterface
+    {
+        int Calculate(int a, int b);
+
+        int TestProperty { get; set; }
+    }
+
+    public abstract class BaseSampleClass
+    {
+        public int Calculate()
+        {
+            return 0;
+        }
+
+        public abstract int Calculate(int a, int b);
+
+        public abstract int Calculate(int a, int b, int c);
+    }
+
+    public class SampleClass : BaseSampleClass
+    {
+
+        public override int Calculate(int a, int b) => 0;
+
+        public sealed override int Calculate(int a, int b, int c) => 0;
+
+        public virtual int DoSth() => 0;
+
+        public int Property { get; set; }
+    }
+
+    internal class MyUnitTests
+    {
+        private void TestOkForAbstractMethod()
+        {
+            var mock = new Mock<BaseSampleClass>();
+            mock.Setup(x => x.Calculate(It.IsAny<int>(), It.IsAny<int>()));
+        }
+
+        private void TestOkForOverrideAbstractMethod()
+        {
+            var mock = new Mock<SampleClass>();
+            mock.Setup(x => x.Calculate(It.IsAny<int>(), It.IsAny<int>()));
+        }
+
+        private void TestOkForInterfaceMethod()
+        {
+            var mock = new Mock<ISampleInterface>();
+            mock.Setup(x => x.Calculate(It.IsAny<int>(), It.IsAny<int>()));
+        }
+
+        private void TestOkForInterfaceProperty()
+        {
+            var mock = new Mock<ISampleInterface>();
+            mock.Setup(x => x.TestProperty);
+        }
+
+        private void TestOkForVirtualMethod()
+        {
+            var mock = new Mock<SampleClass>();
+            mock.Setup(x => x.DoSth());
+        }
+
+        private void TestBadSetupForNonVirtualMethod()
+        {
+            var mock = new Mock<BaseSampleClass>();
+            mock.Setup(x => x.Calculate());
+        }
+
+        private void TestBadSetupForSealedMethod()
+        {
+            var mock = new Mock<SampleClass>();
+            mock.Setup(x => x.Calculate(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()));
+        }
+
+        private void TestBadSetupForNonVirtualProperty()
+        {
+            var mock = new Mock<SampleClass>();
+            mock.Setup(x => x.Property);
+        }
+    }
+}

--- a/Source/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
+++ b/Source/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
@@ -56,6 +56,9 @@
     <Compile Update="Data\NoSealedClassMocks.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Compile>
+    <Compile Update="Data\SetupOnlyForOverridableMembers.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Compile>
   </ItemGroup>
 
 </Project>

--- a/Source/Moq.Analyzers.Test/SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests.ShouldPassIfGoodParameters.approved.txt
+++ b/Source/Moq.Analyzers.Test/SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests.ShouldPassIfGoodParameters.approved.txt
@@ -1,0 +1,24 @@
+﻿Diagnostic 1
+	Id: Moq1200
+	Location: SourceFile(Test0.cs[2075..2088))
+	Highlight: x.Calculate()
+	Lines: mock.Setup(x => x.Calculate());
+	Severity: Error
+	Message: Setup should be used only for overridable members.
+
+Diagnostic 2
+	Id: Moq1200
+	Location: SourceFile(Test0.cs[2241..2303))
+	Highlight: x.Calculate(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())
+	Lines: mock.Setup(x => x.Calculate(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()));
+	Severity: Error
+	Message: Setup should be used only for overridable members.
+
+Diagnostic 3
+	Id: Moq1200
+	Location: SourceFile(Test0.cs[2462..2472))
+	Highlight: x.Property
+	Lines: mock.Setup(x => x.Property);
+	Severity: Error
+	Message: Setup should be used only for overridable members.
+

--- a/Source/Moq.Analyzers.Test/SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests.cs
@@ -1,0 +1,24 @@
+﻿namespace Moq.Analyzers.Test
+{
+    using System.IO;
+    using ApprovalTests;
+    using ApprovalTests.Reporters;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using TestHelper;
+    using Xunit;
+
+    [UseReporter(typeof(DiffReporter))]
+    public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests : DiagnosticVerifier
+    {
+        [Fact]
+        public void ShouldPassIfGoodParameters()
+        {
+            Approvals.Verify(VerifyCSharpDiagnostic(File.ReadAllText("Data/SetupOnlyForOverridableMembers.cs")));
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new SetupShouldBeUsedOnlyForOverridableMembersAnalyzer();
+        }
+    }
+}

--- a/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
+++ b/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
@@ -48,7 +48,7 @@ namespace Moq.Analyzers
             if (lambdaParameters.Count == 0) return;
 
             var setupInvocation = Helpers.FindSetupMethodFromCallbackInvocation(context.SemanticModel, callbackOrReturnsInvocation);
-            var mockedMethodInvocation = Helpers.FindMockedMethodInvocationFromSetupMethod(context.SemanticModel, setupInvocation);
+            var mockedMethodInvocation = Helpers.FindMockedMethodInvocationFromSetupMethod(setupInvocation);
             if (mockedMethodInvocation == null) return;
 
             var mockedMethodArguments = mockedMethodInvocation.ArgumentList.Arguments;

--- a/Source/Moq.Analyzers/Diagnostics.cs
+++ b/Source/Moq.Analyzers/Diagnostics.cs
@@ -23,5 +23,10 @@
         internal const string NoMethodsInPropertySetupId = "Moq1101";
         internal const string NoMethodsInPropertySetupTitle = "Moq: Property setup used for a method";
         internal const string NoMethodsInPropertySetupMessage = "SetupGet/SetupSet should be used for properties, not for methods.";
+
+
+        internal const string SetupShouldBeUsedOnlyForOverridableMembersId = "Moq1200";
+        internal const string SetupShouldBeUsedOnlyForOverridableMembersTitle = "Moq: Invalid setup parameter";
+        internal const string SetupShouldBeUsedOnlyForOverridableMembersMessage = "Setup should be used only for overridable members.";
     }
 }

--- a/Source/Moq.Analyzers/Helpers.cs
+++ b/Source/Moq.Analyzers/Helpers.cs
@@ -1,4 +1,6 @@
-﻿namespace Moq.Analyzers
+﻿using Microsoft.CodeAnalysis.CSharp;
+
+namespace Moq.Analyzers
 {
     using System.Collections.Generic;
     using System.Linq;
@@ -64,10 +66,16 @@
             return FindSetupMethodFromCallbackInvocation(semanticModel, method.Expression);
         }
 
-        internal static InvocationExpressionSyntax FindMockedMethodInvocationFromSetupMethod(SemanticModel semanticModel, InvocationExpressionSyntax setupInvocation)
+        internal static InvocationExpressionSyntax FindMockedMethodInvocationFromSetupMethod(InvocationExpressionSyntax setupInvocation)
         {
             var setupLambdaArgument = setupInvocation?.ArgumentList.Arguments[0]?.Expression as LambdaExpressionSyntax;
             return setupLambdaArgument?.Body as InvocationExpressionSyntax;
+        }
+
+        internal static ExpressionSyntax FindMockedMemberExpressionFromSetupMethod(InvocationExpressionSyntax setupInvocation)
+        {
+            var setupLambdaArgument = setupInvocation?.ArgumentList.Arguments[0]?.Expression as LambdaExpressionSyntax;
+            return setupLambdaArgument?.Body as ExpressionSyntax;
         }
 
         internal static IEnumerable<IMethodSymbol> GetAllMatchingMockedMethodSymbolsFromSetupMethodInvocation(SemanticModel semanticModel, InvocationExpressionSyntax setupMethodInvocation)

--- a/Source/Moq.Analyzers/NoMethodsInPropertySetupAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoMethodsInPropertySetupAnalyzer.cs
@@ -35,7 +35,7 @@ namespace Moq.Analyzers
             if (setupGetOrSetMethod == null) return;
             if (setupGetOrSetMethod.Name.ToFullString() != "SetupGet" && setupGetOrSetMethod.Name.ToFullString() != "SetupSet") return;
 
-            var mockedMethodCall = Helpers.FindMockedMethodInvocationFromSetupMethod(context.SemanticModel, setupGetOrSetInvocation);
+            var mockedMethodCall = Helpers.FindMockedMethodInvocationFromSetupMethod(setupGetOrSetInvocation);
             if (mockedMethodCall == null) return;
 
             var mockedMethodSymbol = context.SemanticModel.GetSymbolInfo(mockedMethodCall).Symbol;

--- a/Source/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/Source/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -1,0 +1,56 @@
+namespace Moq.Analyzers
+{
+    using System.Collections.Immutable;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            Diagnostics.SetupShouldBeUsedOnlyForOverridableMembersId,
+            Diagnostics.SetupShouldBeUsedOnlyForOverridableMembersTitle,
+            Diagnostics.SetupShouldBeUsedOnlyForOverridableMembersMessage,
+            Diagnostics.Category,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+        }
+
+        private static void Analyze(SyntaxNodeAnalysisContext context)
+        {
+            var setupInvocation = (InvocationExpressionSyntax)context.Node;
+
+            if (setupInvocation.Expression is MemberAccessExpressionSyntax memberAccessExpression && Helpers.IsMoqSetupMethod(context.SemanticModel, memberAccessExpression))
+            {
+                var mockedMemberExpression = Helpers.FindMockedMemberExpressionFromSetupMethod(setupInvocation);
+                if (mockedMemberExpression == null)
+                {
+                    return;
+                }
+
+                var symbolInfo = context.SemanticModel.GetSymbolInfo(mockedMemberExpression);
+                if (symbolInfo.Symbol is IPropertySymbol || symbolInfo.Symbol is IMethodSymbol)
+                {
+                    if (IsMethodOverridable(symbolInfo.Symbol) == false)
+                    {
+                        var diagnostic = Diagnostic.Create(Rule, mockedMemberExpression.GetLocation());
+                        context.ReportDiagnostic(diagnostic);
+                    }
+                }
+            }
+        }
+
+        private static bool IsMethodOverridable(ISymbol methodSymbol)
+        {
+            return methodSymbol.IsSealed == false && (methodSymbol.IsVirtual || methodSymbol.IsAbstract || methodSymbol.IsOverride);
+        }
+    }
+}


### PR DESCRIPTION
This implementation handles only `Setup()` for methods. The case with properties is currently ignored because is much more complex, especially that `Moq` supports recursive mocking for properties. I've set the default severity level for `ERROR` because it always fails in runtime.