### PR TITLE
New feature: Mock.As() should take interfaces only

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Note: If you are using Visual Studio 2017 then you can additionally install [Moq
 * Moq1100 = Callback signature must match the signature of the mocked method
 * Moq1101 = SetupGet/SetupSet should be used for properties, not for methods
 * Moq1200 = Setup should be used only for overridable members.
+* Moq1300 = Mock.As() should take interfaces only.
 
 ## TODO
 
 * Setup() should be used for methods, not for properties
-* Mock.As<T>() should take interfaces only
 * AdvancedMatcherAttribute should accept only IMatcher types
 * Checks for protected mocks when dynamically referencing their members
 * Setup() requires overridable members

--- a/Source/Moq.Analyzers.Test/AsAcceptOnlyInterfaceAnalyzerTests.ShouldPassIfGoodParameters.approved.txt
+++ b/Source/Moq.Analyzers.Test/AsAcceptOnlyInterfaceAnalyzerTests.ShouldPassIfGoodParameters.approved.txt
@@ -1,0 +1,16 @@
+﻿Diagnostic 1
+	Id: Moq1300
+	Location: SourceFile(Test0.cs[1376..1391))
+	Highlight: BaseSampleClass
+	Lines: mock.As<BaseSampleClass>();
+	Severity: Error
+	Message: Mock.As() should take interfaces only
+
+Diagnostic 2
+	Id: Moq1300
+	Location: SourceFile(Test0.cs[1541..1551))
+	Highlight: OtherClass
+	Lines: mock.As<OtherClass>();
+	Severity: Error
+	Message: Mock.As() should take interfaces only
+

--- a/Source/Moq.Analyzers.Test/AsAcceptOnlyInterfaceAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/AsAcceptOnlyInterfaceAnalyzerTests.cs
@@ -1,0 +1,24 @@
+﻿namespace Moq.Analyzers.Test
+{
+    using System.IO;
+    using ApprovalTests;
+    using ApprovalTests.Reporters;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using TestHelper;
+    using Xunit;
+
+    [UseReporter(typeof(DiffReporter))]
+    public class AsAcceptOnlyInterfaceAnalyzerTests : DiagnosticVerifier
+    {
+        [Fact]
+        public void ShouldPassIfGoodParameters()
+        {
+            Approvals.Verify(VerifyCSharpDiagnostic(File.ReadAllText("Data/AsAcceptOnlyInterface.cs")));
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new AsShouldBeUsedOnlyForInterfaceAnalyzer();
+        }
+    }
+}

--- a/Source/Moq.Analyzers.Test/Data/AsAcceptOnlyInterface.cs
+++ b/Source/Moq.Analyzers.Test/Data/AsAcceptOnlyInterface.cs
@@ -1,0 +1,64 @@
+﻿#pragma warning disable SA1402 // File may only contain a single class
+#pragma warning disable SA1649 // File name must match first type name
+#pragma warning disable SA1502 // Element must not be on a single line
+namespace AsAcceptOnlyInterface
+{
+    using Moq;
+    public interface ISampleInterface
+    {
+        int Calculate(int a, int b);
+
+        int TestProperty { get; set; }
+    }
+
+    public abstract class BaseSampleClass
+    {
+        public int Calculate()
+        {
+            return 0;
+        }
+
+        public abstract int Calculate(int a, int b, int c);
+    }
+
+    public class SampleClass
+    {
+
+        public virtual int Calculate(int a, int b) => 0;
+    }
+
+    public class OtherClass
+    {
+
+        public virtual int Calculate() => 0;
+    }
+
+    internal class MyUnitTests
+    {
+        private void TestOkAsForInterface()
+        {
+            var mock = new Mock<BaseSampleClass>();
+            mock.As<ISampleInterface>();
+        }
+
+        private void TestOkAsForInterfaceWithConfiguration()
+        {
+            var mock = new Mock<BaseSampleClass>();
+            mock.As<ISampleInterface>()
+                .Setup(x=>x.Calculate(It.IsAny<int>(), It.IsAny<int>()))
+                .Returns(10);
+        }
+
+        private void TestBadAsForAbstractClass()
+        {
+            var mock = new Mock<BaseSampleClass>();
+            mock.As<BaseSampleClass>();
+        }
+
+        private void TestBadAsForNonAbstractClass()
+        {
+            var mock = new Mock<BaseSampleClass>();
+            mock.As<OtherClass>();
+        }
+    }
+}

--- a/Source/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
+++ b/Source/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
@@ -56,6 +56,9 @@
     <Compile Update="Data\NoSealedClassMocks.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Compile>
+    <Compile Update="Data\AsAcceptOnlyInterface.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Compile>
     <Compile Update="Data\SetupOnlyForOverridableMembers.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Compile>

--- a/Source/Moq.Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
+++ b/Source/Moq.Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
@@ -1,0 +1,46 @@
+namespace Moq.Analyzers
+{
+    using System.Collections.Immutable;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class AsShouldBeUsedOnlyForInterfaceAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            Diagnostics.AsShouldBeUsedOnlyForInterfaceId,
+            Diagnostics.AsShouldBeUsedOnlyForInterfaceTitle,
+            Diagnostics.AsShouldBeUsedOnlyForInterfaceMessage,
+            Diagnostics.Category,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+        }
+
+        private static void Analyze(SyntaxNodeAnalysisContext context)
+        {
+            var asInvocation = (InvocationExpressionSyntax)context.Node;
+
+            if (asInvocation.Expression is MemberAccessExpressionSyntax memberAccessExpression && Helpers.IsMoqAsMethod(context.SemanticModel, memberAccessExpression))
+            {
+                if (memberAccessExpression.Name is GenericNameSyntax genericName && genericName.TypeArgumentList.Arguments.Count == 1)
+                {
+                    var typeArgument = genericName.TypeArgumentList.Arguments[0];
+                    var symbolInfo = context.SemanticModel.GetSymbolInfo(typeArgument);
+                    if (symbolInfo.Symbol != null && symbolInfo.Symbol is ITypeSymbol typeSymbol && typeSymbol.TypeKind != TypeKind.Interface)
+                    {
+                        var diagnostic = Diagnostic.Create(Rule, typeArgument.GetLocation());
+                        context.ReportDiagnostic(diagnostic);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Source/Moq.Analyzers/Diagnostics.cs
+++ b/Source/Moq.Analyzers/Diagnostics.cs
@@ -28,5 +28,9 @@
         internal const string SetupShouldBeUsedOnlyForOverridableMembersId = "Moq1200";
         internal const string SetupShouldBeUsedOnlyForOverridableMembersTitle = "Moq: Invalid setup parameter";
         internal const string SetupShouldBeUsedOnlyForOverridableMembersMessage = "Setup should be used only for overridable members.";
+
+        internal const string AsShouldBeUsedOnlyForInterfaceId = "Moq1300";
+        internal const string AsShouldBeUsedOnlyForInterfaceTitle = "Moq: Invalid As type parameter";
+        internal const string AsShouldBeUsedOnlyForInterfaceMessage = "Mock.As() should take interfaces only";
     }
 }

--- a/Source/Moq.Analyzers/MoqMethodDescriptor.cs
+++ b/Source/Moq.Analyzers/MoqMethodDescriptor.cs
@@ -1,0 +1,55 @@
+﻿namespace Moq.Analyzers
+{
+    using System.Linq;
+    using System.Text.RegularExpressions;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+    internal class MoqMethodDescriptor
+    {
+        private readonly bool isGeneric;
+
+        public MoqMethodDescriptor(string shortMethodName, Regex fullMethodNamePattern, bool isGeneric=false)
+        {
+            this.isGeneric = isGeneric;
+            ShortMethodName = shortMethodName;
+            FullMethodNamePattern = fullMethodNamePattern;
+        }
+
+        private string ShortMethodName { get; }
+
+        private Regex FullMethodNamePattern { get; }
+
+        public bool IsMoqMethod(SemanticModel semanticModel, MemberAccessExpressionSyntax method)
+        {
+            var methodName = method?.Name.ToString();
+
+            // First fast check before walking semantic model
+            if (DoesShortMethodMatch(methodName) == false) return false;
+
+            var symbolInfo = semanticModel.GetSymbolInfo(method);
+            if (symbolInfo.CandidateReason == CandidateReason.OverloadResolutionFailure)
+            {
+                return symbolInfo.CandidateSymbols.OfType<IMethodSymbol>()
+                    .Any(s => this.FullMethodNamePattern.IsMatch(s.ToString()));
+            }
+            else if (symbolInfo.CandidateReason == CandidateReason.None)
+            {
+                // TODO: Replace regex with something more elegant
+                return symbolInfo.Symbol is IMethodSymbol &&
+                       this.FullMethodNamePattern.IsMatch(symbolInfo.Symbol.ToString());
+            }
+
+            return false;
+        }
+
+        private bool DoesShortMethodMatch(string methodName)
+        {
+            if (isGeneric)
+            {
+                return methodName.StartsWith($"{this.ShortMethodName}<");
+            }
+            return methodName == this.ShortMethodName;
+        }
+    }
+}


### PR DESCRIPTION
I've added an analyzer that verifies if the type parameter accepted by Moq.As represents an interface.