### PR TITLE
Added async result check as rule 1201

### DIFF
--- a/Source/Moq.Analyzers.Test/Data/SetupShouldNotIncludeAsyncResult.cs
+++ b/Source/Moq.Analyzers.Test/Data/SetupShouldNotIncludeAsyncResult.cs
@@ -1,0 +1,37 @@
+﻿#pragma warning disable SA1402 // File may only contain a single class
+#pragma warning disable SA1649 // File name must match first type name
+#pragma warning disable SA1502 // Element must not be on a single line
+
+namespace SetupShouldNotIncludeAsyncResult
+{
+    using Moq;
+    using System.Threading.Tasks;
+
+    public class AsyncClient
+    {
+        public virtual Task VoidAsync() => Task.CompletedTask;
+        public virtual Task<string> GenericAsyncWithConcreteReturn() => Task.FromResult(string.Empty);
+    }
+
+    internal class MyUnitTests
+    {
+        private void TestOkForTask()
+        {
+            var mock = new Mock<AsyncClient>();
+            mock.Setup(c => c.VoidAsync());
+        }
+
+        private void TestOkForTaskWithConcreteReturn()
+        {
+            var mock = new Mock<AsyncClient>();
+            mock.Setup(c => c.GenericAsyncWithConcreteReturn().Result);
+        }
+
+        private void TestOkForTaskWithConcreteReturnProperSetup()
+        {
+            var mock = new Mock<AsyncClient>();
+            mock.Setup(c => c.GenericAsyncWithConcreteReturn())
+                .ReturnsAsync(string.Empty);
+        }
+    }
+}

--- a/Source/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
+++ b/Source/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
@@ -62,6 +62,9 @@
     <Compile Update="Data\SetupOnlyForOverridableMembers.cs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Compile>
+    <Compile Update="Data\SetupShouldNotIncludeAsyncResult.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Compile>
   </ItemGroup>
 
 </Project>

--- a/Source/Moq.Analyzers.Test/SetupShouldNotIncludeAsyncResultAnalyzerTests.ShouldPassIfSetupProperly.approved.txt
+++ b/Source/Moq.Analyzers.Test/SetupShouldNotIncludeAsyncResultAnalyzerTests.ShouldPassIfSetupProperly.approved.txt
@@ -1,0 +1,8 @@
+﻿Diagnostic 1
+	Id: Moq1201
+	Location: SourceFile(Test0.cs[871..912))
+	Highlight: c.GenericAsyncWithConcreteReturn().Result
+	Lines: mock.Setup(c => c.GenericAsyncWithConcreteReturn().Result);
+	Severity: Error
+	Message: Setup of async methods should use ReturnsAsync instead of .Result
+

--- a/Source/Moq.Analyzers.Test/SetupShouldNotIncludeAsyncResultAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/SetupShouldNotIncludeAsyncResultAnalyzerTests.cs
@@ -1,0 +1,24 @@
+﻿namespace Moq.Analyzers.Test
+{
+    using System.IO;
+    using ApprovalTests;
+    using ApprovalTests.Reporters;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using TestHelper;
+    using Xunit;
+
+    [UseReporter(typeof(DiffReporter))]
+    public class SetupShouldNotIncludeAsyncResultAnalyzerTests : DiagnosticVerifier
+    {
+        [Fact]
+        public void ShouldPassIfSetupProperly()
+        {
+            Approvals.Verify(VerifyCSharpDiagnostic(File.ReadAllText("Data/SetupShouldNotIncludeAsyncResult.cs")));
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new SetupShouldNotIncludeAsyncResultAnalyzer();
+        }
+    }
+}

--- a/Source/Moq.Analyzers/Diagnostics.cs
+++ b/Source/Moq.Analyzers/Diagnostics.cs
@@ -29,6 +29,10 @@
         internal const string SetupShouldBeUsedOnlyForOverridableMembersTitle = "Moq: Invalid setup parameter";
         internal const string SetupShouldBeUsedOnlyForOverridableMembersMessage = "Setup should be used only for overridable members.";
 
+        internal const string SetupShouldNotIncludeAsyncResultId = "Moq1201";
+        internal const string SetupShouldNotIncludeAsyncResultTitle = SetupShouldBeUsedOnlyForOverridableMembersTitle;
+        internal const string SetupShouldNotIncludeAsyncResultMessage = "Setup of async methods should use ReturnsAsync instead of .Result";
+
         internal const string AsShouldBeUsedOnlyForInterfaceId = "Moq1300";
         internal const string AsShouldBeUsedOnlyForInterfaceTitle = "Moq: Invalid As type parameter";
         internal const string AsShouldBeUsedOnlyForInterfaceMessage = "Mock.As() should take interfaces only";

--- a/Source/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
+++ b/Source/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
@@ -1,0 +1,69 @@
+﻿namespace Moq.Analyzers
+{
+    using System;
+    using System.Collections.Immutable;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class SetupShouldNotIncludeAsyncResultAnalyzer : DiagnosticAnalyzer
+    {
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            Diagnostics.SetupShouldNotIncludeAsyncResultId,
+            Diagnostics.SetupShouldNotIncludeAsyncResultTitle,
+            Diagnostics.SetupShouldNotIncludeAsyncResultMessage,
+            Diagnostics.Category,
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+        }
+
+        private static void Analyze(SyntaxNodeAnalysisContext context)
+        {
+            var setupInvocation = (InvocationExpressionSyntax)context.Node;
+
+            if (setupInvocation.Expression is MemberAccessExpressionSyntax memberAccessExpression && Helpers.IsMoqSetupMethod(context.SemanticModel, memberAccessExpression))
+            {
+                var mockedMemberExpression = Helpers.FindMockedMemberExpressionFromSetupMethod(setupInvocation);
+                if (mockedMemberExpression == null)
+                {
+                    return;
+                }
+
+                var symbolInfo = context.SemanticModel.GetSymbolInfo(mockedMemberExpression);
+                if (symbolInfo.Symbol is IPropertySymbol || symbolInfo.Symbol is IMethodSymbol)
+                {
+                    if (IsMethodOverridable(symbolInfo.Symbol) == false &&
+                        IsMethodReturnTypeTask(symbolInfo.Symbol) == true)
+                    {
+                        var diagnostic = Diagnostic.Create(Rule, mockedMemberExpression.GetLocation());
+                        context.ReportDiagnostic(diagnostic);
+                    }
+                }
+            }
+        }
+
+        private static bool IsMethodOverridable(ISymbol methodSymbol)
+        {
+            return methodSymbol.IsSealed == false && (methodSymbol.IsVirtual || methodSymbol.IsAbstract || methodSymbol.IsOverride);
+        }
+
+        private static bool IsMethodReturnTypeTask(ISymbol methodSymbol)
+        {
+            var type = methodSymbol.ToDisplayString();
+            return type != null &&
+                   (type == "System.Threading.Tasks.Task" ||
+                    type == "System.Threading.ValueTask" ||
+                    type.StartsWith("System.Threading.Tasks.Task<", StringComparison.Ordinal) ||
+                    type.StartsWith("System.Threading.Tasks.ValueTask<", StringComparison.Ordinal) &&
+                    type.EndsWith(".Result", StringComparison.Ordinal));
+        }
+    }
+}


### PR DESCRIPTION
When using the result of an async operation (returning generic Task<>), rule 1200 fires indicating setup should only be used for overridable members. This is technically true because Task<> is abstract, however, the message is not helpful/actionable by a developer.

Added new rule, `Moq1201`, that is triggered when the setup method is for a Task and that Task includes the `.Result`. The error reflects the guidance from Moq, which is to use the `.ReturnsAsync` method for setup.

Resolves #4 