### PR TITLE
Additional updates for upcoming release

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Note: If you are using Visual Studio 2017 then you can additionally install [Moq
 
 ## Detected issues
 
-* Moq1000 = Sealed classes cannot be mocked
-* Moq1001 = Mocked interfaces cannot have constructor parameters
-* Moq1002 = Parameters provided into mock do not match any existing constructors
-* Moq1100 = Callback signature must match the signature of the mocked method
-* Moq1101 = SetupGet/SetupSet should be used for properties, not for methods
+* Moq1000 = Sealed classes cannot be mocked.
+* Moq1001 = Mocked interfaces cannot have constructor parameters.
+* Moq1002 = Parameters provided into mock do not match any existing constructors.
+* Moq1100 = Callback signature must match the signature of the mocked method.
+* Moq1101 = SetupGet/SetupSet should be used for properties, not for methods.
 * Moq1200 = Setup should be used only for overridable members.
 * Moq1201 = Setup of async methods should use `.ReturnsAsync` instance instead of `.Result`.
-* Moq1300 = Mock.As() should take interfaces 
+* Moq1300 = Mock.As() should take interfaces.
 
 ## TODO
 
@@ -22,8 +22,8 @@ Note: If you are using Visual Studio 2017 then you can additionally install [Moq
 * Checks for protected mocks when dynamically referencing their members
 * Setup() requires overridable members
 * Mock.Get() should not take literals
- 
-## How to install:
+
+## How to install
 
 * (Option 1) Install "Moq.Analyzers" NuGet package into test projects. Con: Extension will work for specific projects only. Pro: It will be available for all project developers automatically.
 * (Option 2) Install "Moq.Analyzers" extension into Visual Studio. Con: Every developer must install extension manually. Pro: It works for all your projects.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Note: If you are using Visual Studio 2017 then you can additionally install [Moq
 * Moq1100 = Callback signature must match the signature of the mocked method
 * Moq1101 = SetupGet/SetupSet should be used for properties, not for methods
 * Moq1200 = Setup should be used only for overridable members.
-* Moq1300 = Mock.As() should take interfaces only.
+* Moq1201 = Setup of async methods should use `.ReturnsAsync` instance instead of `.Result`.
+* Moq1300 = Mock.As() should take interfaces 
 
 ## TODO
 

--- a/Source/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
+++ b/Source/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 


### PR DESCRIPTION
- Addition of documentation for rule 1201 added in #5
- Correction of markdown lint issues in root README.md file
- Move test project forward to minimum supported version of .NET Core (3.1, supported until Dec of 2022)