### PR TITLE
Create a basic GitHub Actions pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,66 @@
+name: Main build
+
+on:
+  workflow_dispatch: # Allow running the workflow manually from the GitHub UI
+  push:
+    branches:
+      - main
+  workflow_call: # Allow to be called from the release workflow
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [windows-2022, ubuntu-22.04]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # avoid shallow clone so nbgv can do its work
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: ./global.json
+
+    - name: NuGet Restore
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build --no-restore --configuration Release /bl:./artifacts/logs/release/build.release.binlog
+
+    - name: Test
+      run: dotnet test --no-build --configuration Release
+
+    - name: Publish Test Report
+      uses: dorny/test-reporter@v1
+      if: success() || failure()
+      with:
+        name: .NET Test Report (${{ matrix.os }})
+        path: "artifacts/TestResults/**/*.trx"
+        reporter: dotnet-trx
+        fail-on-error: true
+        fail-on-empty: true
+
+    - name: Upload binlogs
+      uses: actions/upload-artifact@v4
+      with:
+        name: binlogs-${{ matrix.os }}
+        path: ./artifacts/logs
+        if-no-files-found: error
+
+    # TODO: Wire up building packages. Tracked by #13.
+    # - name: Upload packages
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: packages-${{ matrix.os }}
+    #     path: |
+    #       ./artifacts/package
+    #     if-no-files-found: error

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,14 @@
+name: PR build
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  build:
+    uses: ./.github/workflows/main.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release publish
+
+on:
+  workflow_dispatch: # Allow running the workflow manually from the GitHub UI
+  release:
+    types:
+      - published # Run the workflow when a new GitHub release is published
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+
+jobs:
+  build:
+    uses: ./.github/workflows/main.yml
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download packages
+        uses: actions/download-artifact@v4
+        with:
+          path: packages
+          pattern: packages-windows-*
+          merge-multiple: true
+      - name: Publish NuGet package
+        shell: pwsh
+        run: |
+          foreach ($file in (Get-ChildItem ./packages/release -Recurse -Include *.nupkg)) {
+            echo "NuGet publish for file: '$file'"
+            # TODO: Wire to publishing packages
+            # dotnet nuget push $file --api-key "${{ secrets.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
+          }

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.101",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
Create a basic GitHub actions pipeline for build / test. I've commented out code relating to making NuGet packages build artifacts, and commented out the NuGet publish step from the release pipeline. Those are tracked via issues.

I also added a `global.json` so that the actions runner uses a consistent version of the dotnet SDK.

Fixes #10.