### PR TITLE
Fix GitHub actions branch 'main' -> 'master'

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: # Allow running the workflow manually from the GitHub UI
   push:
     branches:
-      - main
+      - master
   workflow_call: # Allow to be called from the release workflow
 
 permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,15 +39,16 @@ jobs:
     - name: Test
       run: dotnet test --no-build --configuration Release
 
-    - name: Publish Test Report
-      uses: dorny/test-reporter@v1
-      if: success() || failure()
-      with:
-        name: .NET Test Report (${{ matrix.os }})
-        path: "artifacts/TestResults/**/*.trx"
-        reporter: dotnet-trx
-        fail-on-error: true
-        fail-on-empty: true
+    # TODO: Create a TRX report and upload as an artifact. Tracked by #22. 
+    # - name: Publish Test Report
+    #   uses: dorny/test-reporter@v1
+    #   if: success() || failure()
+    #   with:
+    #     name: .NET Test Report (${{ matrix.os }})
+    #     path: "artifacts/TestResults/**/*.trx"
+    #     reporter: dotnet-trx
+    #     fail-on-error: true
+    #     fail-on-empty: true
 
     - name: Upload binlogs
       uses: actions/upload-artifact@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,8 @@ name: PR build
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches:
+      - master
 
 permissions:
   contents: read

--- a/Source/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
+++ b/Source/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
   </PropertyGroup>
 


### PR DESCRIPTION
Copy/paste error on my part. The default branch is `master` but I used `main`. Wasn't able to test until the pipelines were merged.

In order to verify the tests pass I also needed to:

1. Upgrade the tests from the unsupported `netcoreapp3.1` to `net6.0`.
2. Disable uploading the test report until #22 is fixed

Verified they run now:

![image](https://github.com/Litee/moq.analyzers/assets/51421/88b41173-c559-4e98-b315-1cb97ec8d1dd)
