### PR TITLE
Use .NET 8 SDK's artifacts output and enable test reports in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,16 +39,15 @@ jobs:
     - name: Test
       run: dotnet test --no-build --configuration Release
 
-    # TODO: Create a TRX report and upload as an artifact. Tracked by #22. 
-    # - name: Publish Test Report
-    #   uses: dorny/test-reporter@v1
-    #   if: success() || failure()
-    #   with:
-    #     name: .NET Test Report (${{ matrix.os }})
-    #     path: "artifacts/TestResults/**/*.trx"
-    #     reporter: dotnet-trx
-    #     fail-on-error: true
-    #     fail-on-empty: true
+    - name: Publish Test Report
+      uses: dorny/test-reporter@v1
+      if: success() || failure()
+      with:
+        name: .NET Test Report (${{ matrix.os }})
+        path: "artifacts/TestResults/**/*.trx"
+        reporter: dotnet-trx
+        fail-on-error: true
+        fail-on-empty: true
 
     - name: Upload binlogs
       uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,14 +40,12 @@ jobs:
       run: dotnet test --no-build --configuration Release
 
     - name: Publish Test Report
-      uses: dorny/test-reporter@v1
+      uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
-        name: .NET Test Report (${{ matrix.os }})
+        name: .NET Test Reports (${{ matrix.os }})
         path: "artifacts/TestResults/**/*.trx"
-        reporter: dotnet-trx
-        fail-on-error: true
-        fail-on-empty: true
+        if-no-files-found: error
 
     - name: Upload binlogs
       uses: actions/upload-artifact@v4

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <RepoRoot>$(MSBuildThisFileDirectory)</RepoRoot>
+  </PropertyGroup>
+
+  <Import Project="build/targets/artifacts/Artifacts.props" />
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,4 +4,5 @@
   </PropertyGroup>
 
   <Import Project="build/targets/artifacts/Artifacts.props" />
+  <Import Project="build/targets/tests/Tests.props" />
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="build/targets/artifacts/Artifacts.targets" />
+</Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,3 +1,4 @@
 <Project>
   <Import Project="build/targets/artifacts/Artifacts.targets" />
+  <Import Project="build/targets/tests/Tests.targets" />
 </Project>

--- a/build/targets/artifacts/Artifacts.props
+++ b/build/targets/artifacts/Artifacts.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
     <ArtifactsPath>$(RepoRoot)/artifacts</ArtifactsPath>
+    <ArtifactsTestResultsPath>$(ArtifactsPath)/TestResults</ArtifactsTestResultsPath>
   </PropertyGroup>
 </Project>

--- a/build/targets/artifacts/Artifacts.props
+++ b/build/targets/artifacts/Artifacts.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <ArtifactsPath>$(RepoRoot)/artifacts</ArtifactsPath>
+  </PropertyGroup>
+</Project>

--- a/build/targets/artifacts/Artifacts.targets
+++ b/build/targets/artifacts/Artifacts.targets
@@ -1,0 +1,2 @@
+<Project>
+</Project>

--- a/build/targets/tests/Tests.props
+++ b/build/targets/tests/Tests.props
@@ -1,0 +1,2 @@
+<Project>
+</Project>

--- a/build/targets/tests/Tests.targets
+++ b/build/targets/tests/Tests.targets
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup Condition=" '$(IsTestProject)' == 'true' ">
+    <!-- Enable test logging to TRX files and place them in the artifacts directory -->
+    <VSTestLogger>trx%3bLogFileName=$(MSBuildProjectName).trx</VSTestLogger>
+    <VSTestResultsDirectory Condition="'$(VSTestResultsDirectory)' == ''">$(ArtifactsTestResultsPath)/$(TargetFramework)</VSTestResultsDirectory>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Fixes #22.

- Add `Directory.Build.props` and `.targets` for build customization
- Enable .NET 8 SDK's simplified artifacts output feature
- Enable TRX files in VSTest
- Update CI pipeline to publish `.trx` files as artifacts