### PR TITLE
Add .nupkg baseline with Verify

### DIFF
--- a/Source/Moq.Analyzers.Test/ModuleInitializer.cs
+++ b/Source/Moq.Analyzers.Test/ModuleInitializer.cs
@@ -1,0 +1,14 @@
+﻿namespace Moq.Analyzers.Test
+{
+    using System.Runtime.CompilerServices;
+    using VerifyTests;
+
+    public static class ModuleInitializer
+    {
+        [ModuleInitializer]
+        public static void Initialize()
+        {
+            VerifyNupkg.Initialize();
+        }
+    }
+}

--- a/Source/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
+++ b/Source/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
@@ -14,6 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="GetPackFromProject" Version="1.0.6">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.6.1" />
@@ -26,6 +30,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Verify.Nupkg" Version="1.1.1" />
     <PackageReference Include="Verify.Xunit" Version="24.2.0" />
     <PackageReference Include="xunit" Version="2.8.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
@@ -34,8 +39,7 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Moq.Analyzers\Moq.Analyzers.csproj">
-    </ProjectReference>
+    <ProjectReference Include="..\Moq.Analyzers\Moq.Analyzers.csproj" AddPackageAsOutput="true" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Data\CallbackSignatureShouldMatchMockedMethod.cs">

--- a/Source/Moq.Analyzers.Test/PackageTests.Baseline#contents.verified.txt
+++ b/Source/Moq.Analyzers.Test/PackageTests.Baseline#contents.verified.txt
@@ -1,0 +1,12 @@
+﻿/
+|-- Moq.Analyzers.nuspec
+|-- analyzers
+|   |-- dotnet
+|   |   |-- cs
+|   |   |   |-- Moq.Analyzers.dll
+|-- lib
+|   |-- netstandard2.0
+|   |   |-- Moq.Analyzers.dll
+|-- tools
+|   |-- install.ps1
+|   |-- uninstall.ps1

--- a/Source/Moq.Analyzers.Test/PackageTests.Baseline#manifest.verified.nuspec
+++ b/Source/Moq.Analyzers.Test/PackageTests.Baseline#manifest.verified.nuspec
@@ -1,0 +1,17 @@
+﻿<package>
+  <metadata>
+    <id>Moq.Analyzers</id>
+    <version>********</version>
+    <authors>Andrey "Litee" Lipatkin</authors>
+    <licenseUrl>https://github.com/Litee/moq.analyzers/blob/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/Litee/moq.analyzers</projectUrl>
+    <description>Roslyn analyzer that helps to write unit tests using Moq mocking library by highlighting typical errors and suggesting quick fixes. Port of Resharper extension to Roslyn. Find the full list of detected issues at project GitHub page.</description>
+    <releaseNotes>Upgraded to support Visual Studio 2019</releaseNotes>
+    <copyright>2015-2019 Andrey Lipatkin</copyright>
+    <tags>moq, mock, test, analyzers</tags>
+    <repository type="git" commit="****************************************" />
+    <dependencies>
+      <group targetFramework=".NETStandard2.0" />
+    </dependencies>
+  </metadata>
+</package>

--- a/Source/Moq.Analyzers.Test/PackageTests.cs
+++ b/Source/Moq.Analyzers.Test/PackageTests.cs
@@ -1,0 +1,28 @@
+﻿namespace Moq.Analyzers.Test
+{
+    using System.IO;
+    using System.Linq;
+    using System.Reflection;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public class PackageTests
+    {
+        private static readonly FileInfo Package;
+
+        static PackageTests()
+        {
+            Package = new FileInfo(Assembly.GetExecutingAssembly().Location)
+                .Directory!
+                .GetFiles("Moq.Analyzers*.nupkg")
+                .OrderByDescending(f => f.LastWriteTimeUtc)
+                .First();
+        }
+
+        [Fact]
+        public Task Baseline()
+        {
+            return VerifyFile(Package).ScrubNuspec();
+        }
+    }
+}


### PR DESCRIPTION
Add a test that inspects the `.nupkg` created as part of the build (via `<GeneratePackageOnBuild>`) and dumps the manifest and file structure to prevent accidental regressions in the package format.