### PR TITLE
Update main.yml to upload .received on failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,14 @@ jobs:
         path: "artifacts/TestResults/**/*.trx"
         if-no-files-found: error
 
+    - name: Upload Test Results
+      uses: actions/upload-artifact@v2
+      if: failure()      
+      with:
+        name: verify-test-results
+        path: |
+          **/*.received.*
+
     - name: Upload binlogs
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
When using Verify, when there is a failure upload the *.received.* files for comparison (in case of LF or BOM differences, not just contents).