### PR TITLE
Set package README, license expression, and development dependency

### DIFF
--- a/Source/Moq.Analyzers.Test/PackageTests.Baseline#contents.verified.txt
+++ b/Source/Moq.Analyzers.Test/PackageTests.Baseline#contents.verified.txt
@@ -1,5 +1,6 @@
 ﻿/
 |-- Moq.Analyzers.nuspec
+|-- README.md
 |-- analyzers
 |   |-- dotnet
 |   |   |-- cs

--- a/Source/Moq.Analyzers.Test/PackageTests.Baseline#manifest.verified.nuspec
+++ b/Source/Moq.Analyzers.Test/PackageTests.Baseline#manifest.verified.nuspec
@@ -3,6 +3,7 @@
     <id>Moq.Analyzers</id>
     <version>********</version>
     <authors>Andrey "Litee" Lipatkin</authors>
+    <developmentDependency>true</developmentDependency>
     <license type="expression">BSD-3-Clause</license>
     <licenseUrl>https://licenses.nuget.org/BSD-3-Clause</licenseUrl>
     <readme>README.md</readme>

--- a/Source/Moq.Analyzers.Test/PackageTests.Baseline#manifest.verified.nuspec
+++ b/Source/Moq.Analyzers.Test/PackageTests.Baseline#manifest.verified.nuspec
@@ -3,7 +3,8 @@
     <id>Moq.Analyzers</id>
     <version>********</version>
     <authors>Andrey "Litee" Lipatkin</authors>
-    <licenseUrl>https://github.com/Litee/moq.analyzers/blob/master/LICENSE</licenseUrl>
+    <license type="expression">BSD-3-Clause</license>
+    <licenseUrl>https://licenses.nuget.org/BSD-3-Clause</licenseUrl>
     <projectUrl>https://github.com/Litee/moq.analyzers</projectUrl>
     <description>Roslyn analyzer that helps to write unit tests using Moq mocking library by highlighting typical errors and suggesting quick fixes. Port of Resharper extension to Roslyn. Find the full list of detected issues at project GitHub page.</description>
     <releaseNotes>Upgraded to support Visual Studio 2019</releaseNotes>

--- a/Source/Moq.Analyzers.Test/PackageTests.Baseline#manifest.verified.nuspec
+++ b/Source/Moq.Analyzers.Test/PackageTests.Baseline#manifest.verified.nuspec
@@ -5,6 +5,7 @@
     <authors>Andrey "Litee" Lipatkin</authors>
     <license type="expression">BSD-3-Clause</license>
     <licenseUrl>https://licenses.nuget.org/BSD-3-Clause</licenseUrl>
+    <readme>README.md</readme>
     <projectUrl>https://github.com/Litee/moq.analyzers</projectUrl>
     <description>Roslyn analyzer that helps to write unit tests using Moq mocking library by highlighting typical errors and suggesting quick fixes. Port of Resharper extension to Roslyn. Find the full list of detected issues at project GitHub page.</description>
     <releaseNotes>Upgraded to support Visual Studio 2019</releaseNotes>

--- a/Source/Moq.Analyzers/Moq.Analyzers.csproj
+++ b/Source/Moq.Analyzers/Moq.Analyzers.csproj
@@ -31,7 +31,7 @@
   <PropertyGroup>
     <PackageId>Moq.Analyzers</PackageId>
     <Authors>Andrey "Litee" Lipatkin</Authors>
-    <PackageLicenseUrl>https://github.com/Litee/moq.analyzers/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Litee/moq.analyzers</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Description>Roslyn analyzer that helps to write unit tests using Moq mocking library by highlighting typical errors and suggesting quick fixes. Port of Resharper extension to Roslyn. Find the full list of detected issues at project GitHub page.</Description>

--- a/Source/Moq.Analyzers/Moq.Analyzers.csproj
+++ b/Source/Moq.Analyzers/Moq.Analyzers.csproj
@@ -39,6 +39,7 @@
     <PackageReleaseNotes>Upgraded to support Visual Studio 2019</PackageReleaseNotes>
     <Copyright>2015-2019 Andrey Lipatkin</Copyright>
     <PackageTags>moq, mock, test, analyzers</PackageTags>
+    <DevelopmentDependency>true</DevelopmentDependency> 
     <NoPackageAnalysis>true</NoPackageAnalysis>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>

--- a/Source/Moq.Analyzers/Moq.Analyzers.csproj
+++ b/Source/Moq.Analyzers/Moq.Analyzers.csproj
@@ -34,6 +34,7 @@
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Litee/moq.analyzers</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>Roslyn analyzer that helps to write unit tests using Moq mocking library by highlighting typical errors and suggesting quick fixes. Port of Resharper extension to Roslyn. Find the full list of detected issues at project GitHub page.</Description>
     <PackageReleaseNotes>Upgraded to support Visual Studio 2019</PackageReleaseNotes>
     <Copyright>2015-2019 Andrey Lipatkin</Copyright>
@@ -62,6 +63,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="$(RepoRoot)\README.md" Pack="true" PackagePath="/"/>
     <None Update="tools\*.ps1" CopyToOutputDirectory="Always" Pack="true" PackagePath="" />
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>


### PR DESCRIPTION
Contributes to #31 (more fixes needed)

This brings our NuGet package closer to best practices:

- Swaps the license URL for an expression. This makes automated compliance easier for users
- Add our README to the package so it shows up on NuGet.org
- Mark the package as a development dependency so it doesn't show up as a dependency if users' packages