### PR TITLE
Remove package dependencies and don't publish analyzer as a lib

### DIFF
--- a/Source/Moq.Analyzers.Test/PackageTests.Baseline#contents.verified.txt
+++ b/Source/Moq.Analyzers.Test/PackageTests.Baseline#contents.verified.txt
@@ -5,9 +5,6 @@
 |   |-- dotnet
 |   |   |-- cs
 |   |   |   |-- Moq.Analyzers.dll
-|-- lib
-|   |-- netstandard2.0
-|   |   |-- Moq.Analyzers.dll
 |-- tools
 |   |-- install.ps1
 |   |-- uninstall.ps1

--- a/Source/Moq.Analyzers.Test/PackageTests.Baseline#manifest.verified.nuspec
+++ b/Source/Moq.Analyzers.Test/PackageTests.Baseline#manifest.verified.nuspec
@@ -13,8 +13,5 @@
     <copyright>2015-2019 Andrey Lipatkin</copyright>
     <tags>moq, mock, test, analyzers</tags>
     <repository type="git" url="https://github.com/********/moq.analyzers.git" commit="****************************************" />
-    <dependencies>
-      <group targetFramework=".NETStandard2.0" />
-    </dependencies>
   </metadata>
 </package>

--- a/Source/Moq.Analyzers/Moq.Analyzers.csproj
+++ b/Source/Moq.Analyzers/Moq.Analyzers.csproj
@@ -4,7 +4,8 @@
     <AssemblyName>Moq.Analyzers</AssemblyName>
     <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <IncludeBuildOutput>false</IncludeBuildOutput><!-- Don't place the output assembly in the package's lib/ folder -->
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking><!-- Don't add the TargetFramework as a package dependency -->
   </PropertyGroup>
 
   <PropertyGroup Label="Package metadata">


### PR DESCRIPTION
Fixes #31.

Address two related issues:

1. Don't pack the analyzer in the `lib/` folder, as that makes it an input to the user's compilation
2. Because there is no lib, suppress the dependency on .NET Standard 2.0, as that's an implementation detail of the analyzer and not a requirement of the package.

To do that I also removed the `<NoPackageAnalysis>`, which disables all package analysis, and instead fixed the raised issues via `<IncludeBuildOutput>` and `<SuppressDependenciesWhenPacking>`.