### PR TITLE
Update Moq.Analyzers.csproj NuGet package metadata

### DIFF
--- a/Source/Moq.Analyzers.Test/PackageTests.Baseline#manifest.verified.nuspec
+++ b/Source/Moq.Analyzers.Test/PackageTests.Baseline#manifest.verified.nuspec
@@ -1,17 +1,17 @@
-﻿<package>
+<package>
   <metadata>
     <id>Moq.Analyzers</id>
     <version>********</version>
-    <authors>Andrey "Litee" Lipatkin</authors>
+    <authors>Matt Kotsenas, Andrey "Litee" Lipatkin, Richard Murillo</authors>
     <developmentDependency>true</developmentDependency>
     <license type="expression">BSD-3-Clause</license>
     <licenseUrl>https://licenses.nuget.org/BSD-3-Clause</licenseUrl>
     <readme>README.md</readme>
     <projectUrl>https://github.com/Litee/moq.analyzers</projectUrl>
     <description>Roslyn analyzer that helps to write unit tests using Moq mocking library by highlighting typical errors and suggesting quick fixes. Port of Resharper extension to Roslyn. Find the full list of detected issues at project GitHub page.</description>
-    <releaseNotes>Upgraded to support Visual Studio 2019</releaseNotes>
-    <copyright>2015-2019 Andrey Lipatkin</copyright>
-    <tags>moq, mock, test, analyzers</tags>
+    <releaseNotes>A changelog is available at https://github.com/Litee/moq.analyzers/releases</releaseNotes>
+    <copyright>2017 Andrey Lipatkin</copyright>
+    <tags>moq, tdd, mocking, mocks, unittesting, agile, unittest, mock, test, analyzers</tags>
     <repository type="git" url="https://github.com/********/moq.analyzers.git" commit="****************************************" />
   </metadata>
 </package>

--- a/Source/Moq.Analyzers/Moq.Analyzers.csproj
+++ b/Source/Moq.Analyzers/Moq.Analyzers.csproj
@@ -18,7 +18,7 @@
     <Description>Roslyn analyzer that helps to write unit tests using Moq mocking library by highlighting typical errors and suggesting quick fixes. Port of Resharper extension to Roslyn. Find the full list of detected issues at project GitHub page.</Description>
     <PackageReleaseNotes>Upgraded to support Visual Studio 2019</PackageReleaseNotes>
     <Copyright>2017 Andrey Lipatkin</Copyright>
-    <PackageTags>moq, mock, test, analyzers</PackageTags>
+    <PackageTags>moq, tdd, mocking, mocks, unittesting, agile, unittest, mock, test, analyzers</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency> 
   </PropertyGroup>
 

--- a/Source/Moq.Analyzers/Moq.Analyzers.csproj
+++ b/Source/Moq.Analyzers/Moq.Analyzers.csproj
@@ -10,7 +10,7 @@
 
   <PropertyGroup Label="Package metadata">
     <PackageId>Moq.Analyzers</PackageId>
-    <Authors>Andrey "Litee" Lipatkin</Authors>
+    <Authors>Matt Kotsenas, Andrey "Litee" Lipatkin, Richard Murillo</Authors>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Litee/moq.analyzers</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/Source/Moq.Analyzers/Moq.Analyzers.csproj
+++ b/Source/Moq.Analyzers/Moq.Analyzers.csproj
@@ -16,7 +16,7 @@
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>Roslyn analyzer that helps to write unit tests using Moq mocking library by highlighting typical errors and suggesting quick fixes. Port of Resharper extension to Roslyn. Find the full list of detected issues at project GitHub page.</Description>
-    <PackageReleaseNotes>Upgraded to support Visual Studio 2019</PackageReleaseNotes>
+    <PackageReleaseNotes>A changelog is available at https://github.com/Litee/moq.analyzers/releases</PackageReleaseNotes>
     <Copyright>2017 Andrey Lipatkin</Copyright>
     <PackageTags>moq, tdd, mocking, mocks, unittesting, agile, unittest, mock, test, analyzers</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency> 

--- a/Source/Moq.Analyzers/Moq.Analyzers.csproj
+++ b/Source/Moq.Analyzers/Moq.Analyzers.csproj
@@ -17,7 +17,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>Roslyn analyzer that helps to write unit tests using Moq mocking library by highlighting typical errors and suggesting quick fixes. Port of Resharper extension to Roslyn. Find the full list of detected issues at project GitHub page.</Description>
     <PackageReleaseNotes>Upgraded to support Visual Studio 2019</PackageReleaseNotes>
-    <Copyright>2015-2019 Andrey Lipatkin</Copyright>
+    <Copyright>2017 Andrey Lipatkin</Copyright>
     <PackageTags>moq, mock, test, analyzers</PackageTags>
     <DevelopmentDependency>true</DevelopmentDependency> 
   </PropertyGroup>


### PR DESCRIPTION
- Conform to value in LICENSE file
- Update Nuget package metadata
- Update Nuspec baseline

Fixes #46 and fixes #47