### PR TITLE
Update release.yml permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,10 @@ on:
       - published # Run the workflow when a new GitHub release is published
 
 permissions:
+  security-events: write  # required for CodeQL
+  packages: read
   contents: read
   actions: read
-  checks: write
 
 jobs:
   build:


### PR DESCRIPTION
Failed with error

```
The workflow is not valid. .github/workflows/release.yml (Line: 15, Col: 3): Error calling workflow 'Litee/moq.analyzers/.github/workflows/main.yml@3f7a811a4ef5e55ed118b196f755257f9c334ac9'. The workflow is requesting 'packages: read, security-events: write', but is only allowed 'packages: none, security-events: none'.
```