### PR TITLE
Add cancellation tokens to methods that have a parameter but we don't pass

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -375,3 +375,7 @@ dotnet_naming_style.s_camelcase.required_suffix =
 dotnet_naming_style.s_camelcase.word_separator =
 dotnet_naming_style.s_camelcase.capitalization = camel_case
 
+# MA0040: Forward the CancellationToken parameter to methods that take one
+dotnet_diagnostic.MA0040.severity = error
+# Async analyzer
+dotnet_diagnostic.CA2016.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -184,9 +184,6 @@ csharp_space_between_square_brackets = false
 csharp_preserve_single_line_blocks = true
 csharp_preserve_single_line_statements = true
 
-# Async analyzer
-dotnet_diagnostic.CA2016.severity = error
-
 #### Naming styles ####
 [*.{cs,vb}]
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,11 +3,10 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
-
   <Import Project="build/targets/reproducible/Packages.props" />
-
   <ItemGroup>
     <PackageVersion Include="GetPackFromProject" Version="1.0.6" />
+    <PackageVersion Include="Meziantou.Analyzer" Version="2.0.155" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.6.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />

--- a/Source/Moq.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/Source/Moq.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -56,7 +56,7 @@ public abstract partial class DiagnosticVerifier
         {
             Debug.Assert(analyzer != null, nameof(analyzer) + " != null");
             var compilationWithAnalyzers = project.GetCompilationAsync().Result.WithAnalyzers(ImmutableArray.Create(analyzer));
-            var diags = compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().Result;
+            var diags = compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync(compilationWithAnalyzers.CancellationToken).Result;
             foreach (var diag in diags)
             {
                 if (diag.Location == Location.None || diag.Location.IsInMetadata)
@@ -68,7 +68,7 @@ public abstract partial class DiagnosticVerifier
                     for (int i = 0; i < documents.Length; i++)
                     {
                         var document = documents[i];
-                        var tree = document.GetSyntaxTreeAsync().Result;
+                        var tree = document.GetSyntaxTreeAsync(compilationWithAnalyzers.CancellationToken).Result;
                         if (tree == diag.Location.SourceTree)
                         {
                             diagnostics.Add(diag);

--- a/Source/Moq.Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
+++ b/Source/Moq.Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
@@ -33,7 +33,7 @@ public class AsShouldBeUsedOnlyForInterfaceAnalyzer : DiagnosticAnalyzer
             if (memberAccessExpression.Name is GenericNameSyntax genericName && genericName.TypeArgumentList.Arguments.Count == 1)
             {
                 var typeArgument = genericName.TypeArgumentList.Arguments[0];
-                var symbolInfo = context.SemanticModel.GetSymbolInfo(typeArgument);
+                var symbolInfo = context.SemanticModel.GetSymbolInfo(typeArgument, context.CancellationToken);
                 if (symbolInfo.Symbol != null && symbolInfo.Symbol is ITypeSymbol typeSymbol && typeSymbol.TypeKind != TypeKind.Interface)
                 {
                     var diagnostic = Diagnostic.Create(Rule, typeArgument.GetLocation());

--- a/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
+++ b/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
@@ -62,8 +62,8 @@ public class CallbackSignatureShouldMatchMockedMethodAnalyzer : DiagnosticAnalyz
         {
             for (int i = 0; i < mockedMethodArguments.Count; i++)
             {
-                var mockedMethodArgumentType = context.SemanticModel.GetTypeInfo(mockedMethodArguments[i].Expression);
-                var lambdaParameterType = context.SemanticModel.GetTypeInfo(lambdaParameters[i].Type);
+                var mockedMethodArgumentType = context.SemanticModel.GetTypeInfo(mockedMethodArguments[i].Expression, context.CancellationToken);
+                var lambdaParameterType = context.SemanticModel.GetTypeInfo(lambdaParameters[i].Type, context.CancellationToken);
                 string mockedMethodTypeName = mockedMethodArgumentType.ConvertedType.ToString();
                 string lambdaParameterTypeName = lambdaParameterType.ConvertedType.ToString();
                 if (mockedMethodTypeName != lambdaParameterTypeName)

--- a/Source/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
+++ b/Source/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
@@ -70,7 +70,7 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
 
             // Extract types of arguments passed in the constructor call
             var argumentTypes = constructorArguments
-                .Select(arg => context.SemanticModel.GetTypeInfo(arg.Expression).Type)
+                .Select(arg => context.SemanticModel.GetTypeInfo(arg.Expression, context.CancellationToken).Type)
                 .ToArray();
 
             // Check all constructors of the abstract type
@@ -93,7 +93,7 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
     {
         var typeArguments = genericName.TypeArgumentList.Arguments;
         if (typeArguments == null || typeArguments.Count != 1) return null;
-        var mockedTypeSymbolInfo = context.SemanticModel.GetSymbolInfo(typeArguments[0]);
+        var mockedTypeSymbolInfo = context.SemanticModel.GetSymbolInfo(typeArguments[0], context.CancellationToken);
         var mockedTypeSymbol = mockedTypeSymbolInfo.Symbol as INamedTypeSymbol;
         if (mockedTypeSymbol == null || mockedTypeSymbol.TypeKind != TypeKind.Class) return null;
         return mockedTypeSymbol;
@@ -141,7 +141,7 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
 
     private static IMethodSymbol GetConstructorSymbol(SyntaxNodeAnalysisContext context, ObjectCreationExpressionSyntax objectCreation)
     {
-        var constructorSymbolInfo = context.SemanticModel.GetSymbolInfo(objectCreation);
+        var constructorSymbolInfo = context.SemanticModel.GetSymbolInfo(objectCreation, context.CancellationToken);
         var constructorSymbol = constructorSymbolInfo.Symbol as IMethodSymbol;
         return constructorSymbol?.MethodKind == MethodKind.Constructor &&
                constructorSymbol.ContainingType?.ConstructedFrom.ToDisplayString() == "Moq.Mock<T>"

--- a/Source/Moq.Analyzers/Moq.Analyzers.csproj
+++ b/Source/Moq.Analyzers/Moq.Analyzers.csproj
@@ -19,10 +19,14 @@
     <PackageReleaseNotes>A changelog is available at https://github.com/Litee/moq.analyzers/releases</PackageReleaseNotes>
     <Copyright>2017 Andrey Lipatkin</Copyright>
     <PackageTags>moq, tdd, mocking, mocks, unittesting, agile, unittest, mock, test, analyzers</PackageTags>
-    <DevelopmentDependency>true</DevelopmentDependency> 
+    <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Meziantou.Analyzer">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" />
     <PackageReference Include="Roslynator.Analyzers">
@@ -41,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="$(RepoRoot)\README.md" Pack="true" PackagePath="/"/>
+    <None Include="$(RepoRoot)\README.md" Pack="true" PackagePath="/" />
     <None Update="tools\*.ps1" CopyToOutputDirectory="Always" Pack="true" PackagePath="" />
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>

--- a/Source/Moq.Analyzers/Moq.Analyzers.csproj
+++ b/Source/Moq.Analyzers/Moq.Analyzers.csproj
@@ -23,23 +23,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Meziantou.Analyzer">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" />
-    <PackageReference Include="Roslynator.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
     <Compile Update="Resources.Designer.cs" DesignTime="True" AutoGen="True" DependentUpon="Resources.resx" />
     <EmbeddedResource Update="Resources.resx" Generator="ResXFileCodeGenerator" LastGenOutput="Resources.Designer.cs" />
   </ItemGroup>

--- a/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
@@ -46,7 +46,7 @@ public class NoConstructorArgumentsForInterfaceMockAnalyzer : DiagnosticAnalyzer
         if (genericName.Identifier.ToFullString() != "Mock") return;
 
         // Full check
-        var constructorSymbolInfo = context.SemanticModel.GetSymbolInfo(objectCreation);
+        var constructorSymbolInfo = context.SemanticModel.GetSymbolInfo(objectCreation, context.CancellationToken);
         var constructorSymbol = constructorSymbolInfo.Symbol as IMethodSymbol;
         if (constructorSymbol == null || constructorSymbol.ContainingType == null || constructorSymbol.ContainingType.ConstructedFrom == null) return;
         if (constructorSymbol.MethodKind != MethodKind.Constructor) return;
@@ -57,7 +57,7 @@ public class NoConstructorArgumentsForInterfaceMockAnalyzer : DiagnosticAnalyzer
         // Find mocked type
         var typeArguments = genericName.TypeArgumentList.Arguments;
         if (typeArguments == null || typeArguments.Count != 1) return;
-        var symbolInfo = context.SemanticModel.GetSymbolInfo(typeArguments[0]);
+        var symbolInfo = context.SemanticModel.GetSymbolInfo(typeArguments[0], context.CancellationToken);
         var symbol = symbolInfo.Symbol as INamedTypeSymbol;
         if (symbol == null) return;
 

--- a/Source/Moq.Analyzers/NoMethodsInPropertySetupAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoMethodsInPropertySetupAnalyzer.cs
@@ -38,7 +38,7 @@ public class NoMethodsInPropertySetupAnalyzer : DiagnosticAnalyzer
         var mockedMethodCall = Helpers.FindMockedMethodInvocationFromSetupMethod(setupGetOrSetInvocation);
         if (mockedMethodCall == null) return;
 
-        var mockedMethodSymbol = context.SemanticModel.GetSymbolInfo(mockedMethodCall).Symbol;
+        var mockedMethodSymbol = context.SemanticModel.GetSymbolInfo(mockedMethodCall, context.CancellationToken).Symbol;
         if (mockedMethodSymbol == null) return;
 
         var diagnostic = Diagnostic.Create(Rule, mockedMethodCall.GetLocation());

--- a/Source/Moq.Analyzers/NoSealedClassMocksAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoSealedClassMocksAnalyzer.cs
@@ -45,7 +45,7 @@ public class NoSealedClassMocksAnalyzer : DiagnosticAnalyzer
         if (genericName.Identifier.ToFullString() != "Mock") return;
 
         // Full check
-        var constructorSymbolInfo = context.SemanticModel.GetSymbolInfo(objectCreation);
+        var constructorSymbolInfo = context.SemanticModel.GetSymbolInfo(objectCreation, context.CancellationToken);
         var constructorSymbol = constructorSymbolInfo.Symbol as IMethodSymbol;
         if (constructorSymbol == null || constructorSymbol.ContainingType == null || constructorSymbol.ContainingType.ConstructedFrom == null) return;
         if (constructorSymbol.MethodKind != MethodKind.Constructor) return;
@@ -54,7 +54,7 @@ public class NoSealedClassMocksAnalyzer : DiagnosticAnalyzer
         // Find mocked type
         var typeArguments = genericName.TypeArgumentList.Arguments;
         if (typeArguments == null || typeArguments.Count != 1) return;
-        var symbolInfo = context.SemanticModel.GetSymbolInfo(typeArguments[0]);
+        var symbolInfo = context.SemanticModel.GetSymbolInfo(typeArguments[0], context.CancellationToken);
         var symbol = symbolInfo.Symbol as INamedTypeSymbol;
         if (symbol == null) return;
 

--- a/Source/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/Source/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -36,7 +36,7 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnal
                 return;
             }
 
-            var symbolInfo = context.SemanticModel.GetSymbolInfo(mockedMemberExpression);
+            var symbolInfo = context.SemanticModel.GetSymbolInfo(mockedMemberExpression, context.CancellationToken);
             if (symbolInfo.Symbol is IPropertySymbol || symbolInfo.Symbol is IMethodSymbol)
             {
                 if (IsMethodOverridable(symbolInfo.Symbol) == false)

--- a/Source/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
+++ b/Source/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
@@ -37,7 +37,7 @@ public class SetupShouldNotIncludeAsyncResultAnalyzer : DiagnosticAnalyzer
                 return;
             }
 
-            var symbolInfo = context.SemanticModel.GetSymbolInfo(mockedMemberExpression);
+            var symbolInfo = context.SemanticModel.GetSymbolInfo(mockedMemberExpression, context.CancellationToken);
             if (symbolInfo.Symbol is IPropertySymbol || symbolInfo.Symbol is IMethodSymbol)
             {
                 if (IsMethodOverridable(symbolInfo.Symbol) == false &&

--- a/build/targets/compiler/Compiler.props
+++ b/build/targets/compiler/Compiler.props
@@ -14,4 +14,21 @@
   <ItemGroup>
     <AdditionalFiles Include="$(RepoRoot)/Source/stylecop.json" />
   </ItemGroup>
+
+  <ItemGroup>
+      <PackageReference Include="Meziantou.Analyzer">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+      <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" />
+      <PackageReference Include="Roslynator.Analyzers">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+      <PackageReference Include="StyleCop.Analyzers">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      </PackageReference>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Most often this was while getting the type information from the semantic model. In cases where the asynchronous operation is cancelled, the underlying calls would not be aborted because we did not propagate forward the cancellation token. This was not picked up by analyzer CA2016 because the cancellation token is not provided on the method used by `DiagnosticAnalyzer`, but rather on the `SyntaxNodeAnalysisContext` instance passed in. 

The issue was corrected by adding a new analyzer package and enabling an analyzer rule within that package. Both rules are set to error in `.editorconfig` to avoid introducing new code with this issue

Fixes #43 