### PR TITLE
Extract code analysis to its own build slice and update analyzers to latest versions

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,4 +8,5 @@
   <Import Project="build/targets/reproducible/Reproducible.props" />
   <Import Project="build/targets/versioning/Versioning.props" />
   <Import Project="build/targets/tests/Tests.props" />
+  <Import Project="build/targets/codeanalysis/CodeAnalysis.props" />
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -4,4 +4,5 @@
   <Import Project="build/targets/reproducible/Reproducible.targets" />
   <Import Project="build/targets/versioning/Versioning.targets" />
   <Import Project="build/targets/tests/Tests.targets" />
+  <Import Project="build/targets/codeanalysis/CodeAnalysis.targets" />
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,16 +4,13 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <Import Project="build/targets/reproducible/Packages.props" />
+  <Import Project="build/targets/codeanalysis/Packages.props" />
   <ItemGroup>
     <PackageVersion Include="GetPackFromProject" Version="1.0.6" />
-    <PackageVersion Include="Meziantou.Analyzer" Version="2.0.155" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.3" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.6.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageVersion Include="Moq" Version="4.8.2" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.133" />
-    <PackageVersion Include="Roslynator.Analyzers" Version="2.1.0" />
-    <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageVersion Include="Verify.Nupkg" Version="1.1.5" />
     <PackageVersion Include="Verify.Xunit" Version="24.2.0" />
     <PackageVersion Include="xunit" Version="2.8.1" />

--- a/Source/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
+++ b/Source/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
@@ -19,17 +19,8 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="Moq" />
-    <PackageReference Include="Roslynator.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Verify.Nupkg" />
     <PackageReference Include="Verify.Xunit" />
     <PackageReference Include="xunit" />

--- a/Source/Moq.Analyzers/Moq.Analyzers.csproj
+++ b/Source/Moq.Analyzers/Moq.Analyzers.csproj
@@ -23,6 +23,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Update="Resources.Designer.cs" DesignTime="True" AutoGen="True" DependentUpon="Resources.resx" />
     <EmbeddedResource Update="Resources.resx" Generator="ResXFileCodeGenerator" LastGenOutput="Resources.Designer.cs" />
   </ItemGroup>

--- a/build/targets/codeanalysis/CodeAnalysis.props
+++ b/build/targets/codeanalysis/CodeAnalysis.props
@@ -1,0 +1,28 @@
+<Project>
+  <PropertyGroup>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AnalysisMode>preview</AnalysisMode>
+    <WarningLevel>9999</WarningLevel>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="$(RepoRoot)/Source/stylecop.json" Visible="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Meziantou.Analyzer">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
+    <PackageReference Include="Roslynator.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/build/targets/codeanalysis/CodeAnalysis.targets
+++ b/build/targets/codeanalysis/CodeAnalysis.targets
@@ -1,0 +1,2 @@
+<Project>
+</Project>

--- a/build/targets/codeanalysis/Packages.props
+++ b/build/targets/codeanalysis/Packages.props
@@ -1,0 +1,8 @@
+<Project>
+  <ItemGroup>
+    <PackageVersion Include="Meziantou.Analyzer" Version="2.0.155" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.3" />
+    <PackageVersion Include="Roslynator.Analyzers" Version="2.1.0" />
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
+  </ItemGroup>
+</Project>

--- a/build/targets/codeanalysis/Packages.props
+++ b/build/targets/codeanalysis/Packages.props
@@ -1,8 +1,8 @@
 <Project>
   <ItemGroup>
     <PackageVersion Include="Meziantou.Analyzer" Version="2.0.155" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.3" />
-    <PackageVersion Include="Roslynator.Analyzers" Version="2.1.0" />
-    <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
+    <PackageVersion Include="Roslynator.Analyzers" Version="4.12.4" />
+    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
   </ItemGroup>
 </Project>

--- a/build/targets/compiler/Compiler.props
+++ b/build/targets/compiler/Compiler.props
@@ -1,35 +1,7 @@
 <Project>
-  <PropertyGroup Label="Language options">
+  <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
-  <PropertyGroup Label="Code analysis">
-    <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <AnalysisMode>preview</AnalysisMode>
-    <WarningLevel>9999</WarningLevel>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="$(RepoRoot)/Source/stylecop.json" />
-  </ItemGroup>
-
-  <ItemGroup>
-      <PackageReference Include="Meziantou.Analyzer">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all" />
-      <PackageReference Include="Roslynator.Analyzers">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-      <PackageReference Include="StyleCop.Analyzers">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      </PackageReference>
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
This is a preparatory refactoring change for the test updates.

1. Move code analysis build settings from the `compiler` slice to its own `codeanalysis` slice
2. Update `Microsoft.CodeAnalysis.Analyzers`, `Roslynator.Analyzers`, and `StyleCop.Analyzers` to their latest versions
3. Fix some duplicate definitions between the slices and the projects
4. Move `Microsoft.CodeAnalysis.CSharp.Workspaces` out of the code analysis slice because it's part of the analyzer's public API and not a private code analyzer