### PR TITLE
Move test packages to build slice, update to latest version, and enable parallel tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,16 +4,12 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <Import Project="build/targets/reproducible/Packages.props" />
+  <Import Project="build/targets/tests/Packages.props" />
   <Import Project="build/targets/codeanalysis/Packages.props" />
   <ItemGroup>
     <PackageVersion Include="GetPackFromProject" Version="1.0.6" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.6.1" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageVersion Include="Moq" Version="4.8.2" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.133" />
-    <PackageVersion Include="Verify.Nupkg" Version="1.1.5" />
-    <PackageVersion Include="Verify.Xunit" Version="24.2.0" />
-    <PackageVersion Include="xunit" Version="2.8.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1" />
   </ItemGroup>
 </Project>

--- a/Source/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
+++ b/Source/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -18,16 +19,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="Moq" />
-    <PackageReference Include="Verify.Nupkg" />
-    <PackageReference Include="Verify.Xunit" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Moq.Analyzers\Moq.Analyzers.csproj" AddPackageAsOutput="true" />

--- a/build/targets/tests/Packages.props
+++ b/build/targets/tests/Packages.props
@@ -1,0 +1,9 @@
+<Project>
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageVersion Include="Verify.Nupkg" Version="1.1.5" />
+    <PackageVersion Include="Verify.Xunit" Version="24.2.0" />
+    <PackageVersion Include="xunit" Version="2.8.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1" />
+  </ItemGroup>
+</Project>

--- a/build/targets/tests/Packages.props
+++ b/build/targets/tests/Packages.props
@@ -1,8 +1,8 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="Verify.Nupkg" Version="1.1.5" />
-    <PackageVersion Include="Verify.Xunit" Version="24.2.0" />
+    <PackageVersion Include="Verify.Xunit" Version="25.0.1" />
     <PackageVersion Include="xunit" Version="2.8.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1" />
   </ItemGroup>

--- a/build/targets/tests/Packages.props
+++ b/build/targets/tests/Packages.props
@@ -5,5 +5,6 @@
     <PackageVersion Include="Verify.Xunit" Version="25.0.1" />
     <PackageVersion Include="xunit" Version="2.8.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1" />
+    <PackageVersion Include="Meziantou.Xunit.ParallelTestFramework" Version="2.2.0" />
   </ItemGroup>
 </Project>

--- a/build/targets/tests/Tests.props
+++ b/build/targets/tests/Tests.props
@@ -1,5 +1,6 @@
 <Project>
   <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
+    <PackageReference Include="Meziantou.Xunit.ParallelTestFramework" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Verify.Nupkg" />
     <PackageReference Include="Verify.Xunit" />

--- a/build/targets/tests/Tests.props
+++ b/build/targets/tests/Tests.props
@@ -1,2 +1,12 @@
 <Project>
+  <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Verify.Nupkg" />
+    <PackageReference Include="Verify.Xunit" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Another preparatory refactoring change for the test changes.

1. Move PackageVersions for test packages to the build slice
2. Move PackageReferences for test packages to the build slice
3. Update to latest versions of test packages
4. Enable parallel xUnit tests